### PR TITLE
feat: add authenticate path

### DIFF
--- a/src/RefreshCredentials.tsx
+++ b/src/RefreshCredentials.tsx
@@ -5,8 +5,8 @@ import {
   getAddCredentialsLink,
   generateAuthorizationCode,
   Credentials,
-  refreshCredentialsLink
-} from "./api";
+  refreshCredentialsLink, authenticateCredentialsLink,
+} from './api';
 import { Header } from "./Header";
 import { CheckIcon } from "./images/CheckIcon";
 import { PrettyCode } from "./PrettyCode";
@@ -53,7 +53,7 @@ export const RefreshCredentials: React.FC<RefreshCredentialsProps> = ({
             <div>
               <CheckIcon />
             </div>
-            <div className="ml-16 mr-40">
+            <div className="pl-16 pr-40 w-95p">
               <div className="heading-2">
                 Credentials were successfully added to user!
               </div>
@@ -63,7 +63,7 @@ export const RefreshCredentials: React.FC<RefreshCredentialsProps> = ({
                   <div key={credential.id}>
                     <PrettyCode
                       code={JSON.stringify(credential, null, 2)}
-                      className="mt-20"
+                      className="mt-20 ws-pl"
                     />
                     {authorizationCode && (
                       <a

--- a/src/RefreshCredentials.tsx
+++ b/src/RefreshCredentials.tsx
@@ -5,7 +5,8 @@ import {
   getAddCredentialsLink,
   generateAuthorizationCode,
   Credentials,
-  refreshCredentialsLink, authenticateCredentialsLink,
+  refreshCredentialsLink,
+  authenticateCredentialsLink,
 } from './api';
 import { Header } from "./Header";
 import { CheckIcon } from "./images/CheckIcon";
@@ -66,6 +67,7 @@ export const RefreshCredentials: React.FC<RefreshCredentialsProps> = ({
                       className="mt-20 ws-pl"
                     />
                     {authorizationCode && (
+                      <>
                       <a
                         className="button mt-24"
                         href={refreshCredentialsLink(
@@ -76,6 +78,17 @@ export const RefreshCredentials: React.FC<RefreshCredentialsProps> = ({
                       >
                         Refresh credentials
                       </a>
+                        {credential.providerName.includes("open-banking") && <a
+                          className={"button mt-24 ml-16"}
+                          href={authenticateCredentialsLink(
+                            authorizationCode.code,
+                            userId,
+                            credential.id
+                          )}
+                        >
+                          Authenticate PSD2 credentials
+                        </a>}
+                      </>
                     )}
                   </div>
                 ))}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -106,3 +106,23 @@ export const refreshCredentialsLink = (
 
   return `${TINK_LINK_URL}/1.0/credentials/refresh?${params.join("&")}`;
 };
+
+export const authenticateCredentialsLink = (
+  authorizationCode: string,
+  userId: string,
+  credentialsId: string
+) => {
+  // Read more about Tink Link initialization parameters: https://docs.tink.com/api/#initialization-parameters
+  const params = [
+    `client_id=${process.env.REACT_APP_TINK_LINK_PERMANENT_USERS_CLIENT_ID}`,
+    "redirect_uri=http://localhost:3000/callback",
+    "scope=user:read,credentials:read",
+    "market=SE",
+    "locale=en_US",
+    `state=${userId}`,
+    `authorization_code=${authorizationCode}`,
+    `credentials_id=${credentialsId}`,
+  ];
+
+  return `${TINK_LINK_URL}/1.0/credentials/authenticate?${params.join("&")}`;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,10 @@ code {
   justify-content: space-between;
 }
 
+.w-95p {
+width: 95%;
+}
+
 .p-32 {
   padding: 32px;
 }
@@ -206,4 +210,8 @@ a.button {
 
 .text {
   color: #262626;
+}
+
+.ws-pl{
+  white-space: pre-line;
 }


### PR DESCRIPTION
This PR:
* Adds support for the endpoint described in https://docs.tink.com/api/#credentials-manual-authenticate-of-credentials
* Fix a UI bug where beautified JSON was allowed to have infinite width