### PR TITLE
feat(dep-checker): only create PRs for security

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,6 +1,9 @@
 version: 1
 
 update_configs:
-  - package_manager: 'javascript'
-    directory: '/'
-    update_schedule: 'live'
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+    - match:
+        update_type: "security"


### PR DESCRIPTION
### Why

We should not get drowned in PRs about small version bumps, but we must make sure that we don't miss any security related updates.

### What

Update dependabot config

