### PR TITLE
SDK-2045 | chore: assign sdk-maintainer as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tink-ab/sdk-maintainer


### PR DESCRIPTION
### Why

Take clear ownership of the repo.
https://tinkab.atlassian.net/browse/SDK-2045

### What

- Add `CODEOWNERS` file
  -  Assign `@tink-ab/sdk-maintainer` as codeowner of the whole repo
