### PR TITLE
feat(renovate): automatically merge all updates

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,9 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
-    allowed_updates:
-    - match:
-        update_type: "security"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run start:client

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "description": "Automatically merge all updates",
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "pinDigest", "digest", "lockFileMaintenance", "rollback", "bump"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
   ]
 }


### PR DESCRIPTION
### Why

So we don't have to manually merge PRs

### What

1. [feat(renovate): automatically merge all updates](https://github.com/tink-ab/tink-link-web-permanent-users-example/pull/97/commits/0688023ff72acd190f5d8e5dff801900aa81143e)
2. [chore: rm dependabot](https://github.com/tink-ab/tink-link-web-permanent-users-example/pull/97/commits/fc1c72a84d8b875ee5473478fc625bfa4d80e4ef)
3. [feat(github-actions): add build step](https://github.com/tink-ab/tink-link-web-permanent-users-example/pull/97/commits/ceb2bfd72b798c08c2664c4c8e903dc1f00d54a4)

As long as the build step passes, it will merge

### Notes

### Visual references
