### PR TITLE
fix: switch to routes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { createRoot } from "react-dom/client";
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import './index.css';
 import { AddCredentials } from './AddCredentials';
 import { TinkLinkCallback } from './TinkLinkCallback';
 
-ReactDOM.render(
+const rootElement = document.getElementById("root") as HTMLElement;
+const root = createRoot(rootElement );
+
+root.render(
   <Router>
-    <Switch>
-      <Route path="/callback">
-        <TinkLinkCallback />
+    <Routes>
+      <Route path="/callback" element={<TinkLinkCallback />} />
+      <Route path="/" element={<AddCredentials />}>
       </Route>
-      <Route path="/">
-        <AddCredentials />
-      </Route>
-    </Switch>
-  </Router>,
-  document.getElementById('root')
+    </Routes>
+  </Router>
 );


### PR DESCRIPTION
Upgrading to react-router-dom v6 broke the app because "Switch" was replaced by "Routes"